### PR TITLE
CursorifyProvider is not being imported but used.

### DIFF
--- a/docs/custom-cursor.md
+++ b/docs/custom-cursor.md
@@ -47,7 +47,7 @@ export default EmojiCursor
 You can apply custom cursors as follows:
 
 ```tsx
-import { EmojiCursor } from '@cursorify/cursors'
+import { CursorifyProvider, EmojiCursor } from '@cursorify/cursors'
 
 const App = () => {
   return (


### PR DESCRIPTION
In the "Applying Custom Cursor" part of the documentation "CursorifyProvider" is not being imported, but used in the part of the code below. Fixed the imports.

<!-- 1. Verify PR Title -->
<!-- PR Title example: `[FIX | REFACTOR | FEAT | UPDATE | DOCUMENTATION] repair the page layout` -->

<!-- 2. Provide Description of the changes -->

## Description

<!--
- provide a description of the changes made. If there are some pending TODOs, include them there as well.
- Any guidance for reviewers to better understand the changes.
- Any visuals (screenshots, screen recordings) that can give assurance that the changes are safe to merge.
-->

<!-- 3. Add link to the Github Issue for which these changes are made -->

## Related tickets

https://github.com/morethanmin/morethan-log/issues/XX

<!-- 4. Make sure the following actions are checked before finalising your PR -->

## PR Checklist

- [x] I have read the [Contributing Guide](./docs/CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.
