### PR TITLE
Fixed typo in Default cursor card name attribute

### DIFF
--- a/src/pages/cursors/index.tsx
+++ b/src/pages/cursors/index.tsx
@@ -48,7 +48,7 @@ const Cursors: FC = () => {
       <StyledWrapper>
         <Header />
         <main className="common-container clean-list">
-          <CursorCard cursor={<DefaultCursor />} name="DefualtCursor" />
+          <CursorCard cursor={<DefaultCursor />} name="DefaultCursor" />
           <CursorCard cursor={<PhingerCursor />} name="PhingerCursor" />
           <CursorCard cursor={<EmojiCursor />} name="EmojiCursor" />
         </main>


### PR DESCRIPTION
## Description
Just a minor fix to change `DefualtCursor` to `DefaultCursor` in the `name` attribute on the `CursorCard` component.

## PR Checklist

- [x] I have read the [Contributing Guide](./docs/CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.
